### PR TITLE
Add pagination and filtering to fetch_build_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,17 +632,21 @@ curl -X POST http://localhost:8123/mcp \
 ```
 
 ### 7. fetch_build_log
-Fetch the complete build log for a specific build.
+Fetch the build log for a specific build with filtering options to handle large logs.
 
 **Parameters:**
 - `buildId` (required): Build ID to fetch log for
 - `plain` (optional): Return log as plain text (default: true)
-- `archived` (optional): Return log as zip archive (default: false)  
+- `archived` (optional): Return log as zip archive (default: false)
 - `dateFormat` (optional): Custom timestamp format (Java SimpleDateFormat)
+- `maxLines` (optional): Maximum number of lines to return (applied after filtering)
+- `filterPattern` (optional): Regex pattern to filter log lines
+- `severity` (optional): Filter by severity level: "error", "warning", or "info"
+- `tailLines` (optional): Return only the last N lines (applied after filtering)
 
 **Examples:**
 
-Fetch plain text build log:
+Fetch only errors (limited to 50 lines):
 ```bash
 curl -X POST http://localhost:8123/mcp \
   -H "Content-Type: application/json" \
@@ -654,13 +658,15 @@ curl -X POST http://localhost:8123/mcp \
     "params": {
       "name": "fetch_build_log",
       "arguments": {
-        "buildId": "12345"
+        "buildId": "12345",
+        "severity": "error",
+        "maxLines": 50
       }
     }
   }'
 ```
 
-Fetch archived build log:
+Fetch lines matching a pattern:
 ```bash
 curl -X POST http://localhost:8123/mcp \
   -H "Content-Type: application/json" \
@@ -673,13 +679,14 @@ curl -X POST http://localhost:8123/mcp \
       "name": "fetch_build_log",
       "arguments": {
         "buildId": "12345",
-        "archived": true
+        "filterPattern": "test.*failed",
+        "maxLines": 100
       }
     }
   }'
 ```
 
-Fetch log with custom timestamp format:
+Fetch last 200 lines:
 ```bash
 curl -X POST http://localhost:8123/mcp \
   -H "Content-Type: application/json" \
@@ -692,7 +699,26 @@ curl -X POST http://localhost:8123/mcp \
       "name": "fetch_build_log",
       "arguments": {
         "buildId": "12345",
-        "dateFormat": "yyyy-MM-dd HH:mm:ss"
+        "tailLines": 200
+      }
+    }
+  }'
+```
+
+Fetch archived build log:
+```bash
+curl -X POST http://localhost:8123/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-secret" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 15,
+    "method": "tools/call",
+    "params": {
+      "name": "fetch_build_log",
+      "arguments": {
+        "buildId": "12345",
+        "archived": true
       }
     }
   }'

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -64,6 +64,10 @@ func (h *Handler) HandleRequest(ctx context.Context, req json.RawMessage) (inter
 		return h.handleInitialized(baseReq.ID)
 	case "notifications/initialized":
 		return h.handleInitialized(baseReq.ID)
+	case "notifications/cancelled":
+		// Handle cancellation notifications - just log and return nil (no response for notifications)
+		h.logger.Debug("Received cancellation notification")
+		return nil, nil
 	case "resources/list":
 		return h.handleResourcesList(ctx, baseReq.ID, baseReq.Params)
 	case "resources/read":
@@ -76,7 +80,12 @@ func (h *Handler) HandleRequest(ctx context.Context, req json.RawMessage) (inter
 		return h.handlePing(baseReq.ID)
 	default:
 		h.logger.Warn("Unknown method called", "method", baseReq.Method, "id", baseReq.ID)
-		return h.errorResponse(baseReq.ID, -32601, "Method not found", nil), nil
+		// Only return an error response if this is a request (has an ID), not a notification
+		if baseReq.ID != nil {
+			return h.errorResponse(baseReq.ID, -32601, "Method not found", nil), nil
+		}
+		// For notifications, just return nil (no response)
+		return nil, nil
 	}
 }
 
@@ -115,8 +124,11 @@ func (h *Handler) handleResourcesList(ctx context.Context, id interface{}, param
 		URI string `json:"uri"`
 	}
 
-	if err := json.Unmarshal(params, &req); err != nil {
-		return h.errorResponse(id, -32602, "Invalid params", nil), nil
+	// Params can be empty or null for resources/list
+	if len(params) > 0 && string(params) != "null" {
+		if err := json.Unmarshal(params, &req); err != nil {
+			return h.errorResponse(id, -32602, "Invalid params", nil), nil
+		}
 	}
 
 	resources, err := h.listResources(ctx, req.URI)
@@ -322,7 +334,7 @@ func (h *Handler) handleToolsList(id interface{}) (interface{}, error) {
 		},
 		{
 			"name":        "fetch_build_log",
-			"description": "Fetch build log for a specific build",
+			"description": "Fetch build log for a specific build with filtering options",
 			"inputSchema": map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -341,6 +353,23 @@ func (h *Handler) handleToolsList(id interface{}) (interface{}, error) {
 					"dateFormat": map[string]interface{}{
 						"type":        "string",
 						"description": "Custom timestamp format (Java SimpleDateFormat)",
+					},
+					"maxLines": map[string]interface{}{
+						"type":        "integer",
+						"description": "Maximum number of lines to return (limits output after filtering)",
+					},
+					"filterPattern": map[string]interface{}{
+						"type":        "string",
+						"description": "Regex pattern to filter log lines (only matching lines are returned)",
+					},
+					"severity": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by severity level: 'error', 'warning', or 'info'",
+						"enum":        []string{"error", "warning", "info"},
+					},
+					"tailLines": map[string]interface{}{
+						"type":        "integer",
+						"description": "Return only the last N lines (applied after filtering, before maxLines)",
 					},
 				},
 				"required": []string{"buildId"},
@@ -444,6 +473,7 @@ func (h *Handler) handleToolsCall(ctx context.Context, id interface{}, params js
 
 	result, err := h.callTool(ctx, req.Name, req.Arguments)
 	if err != nil {
+		h.logger.Error("Tool execution failed", "tool", req.Name, "error", err.Error())
 		return h.errorResponse(id, -32603, "Tool execution failed", err.Error()), nil
 	}
 
@@ -490,16 +520,53 @@ func (h *Handler) errorResponse(id interface{}, code int, message string, data i
 
 // listResources lists available resources
 func (h *Handler) listResources(ctx context.Context, uri string) ([]interface{}, error) {
-	switch {
-	case uri == "teamcity://projects" || uri == "":
+	// When uri is empty, return the list of available resource types (not the actual data)
+	if uri == "" {
+		return []interface{}{
+			map[string]interface{}{
+				"uri":         "teamcity://projects",
+				"name":        "Projects",
+				"description": "TeamCity projects",
+				"mimeType":    "application/json",
+			},
+			map[string]interface{}{
+				"uri":         "teamcity://buildTypes",
+				"name":        "Build Types",
+				"description": "TeamCity build configurations",
+				"mimeType":    "application/json",
+			},
+			map[string]interface{}{
+				"uri":         "teamcity://builds",
+				"name":        "Builds",
+				"description": "Recent TeamCity builds",
+				"mimeType":    "application/json",
+			},
+			map[string]interface{}{
+				"uri":         "teamcity://agents",
+				"name":        "Agents",
+				"description": "TeamCity build agents",
+				"mimeType":    "application/json",
+			},
+			map[string]interface{}{
+				"uri":         "teamcity://runtime",
+				"name":        "Runtime Information",
+				"description": "Current server date, time, and runtime information",
+				"mimeType":    "application/json",
+			},
+		}, nil
+	}
+
+	// When a specific URI is requested, fetch the actual data
+	switch uri {
+	case "teamcity://projects":
 		return h.listProjects(ctx)
-	case uri == "teamcity://buildTypes":
+	case "teamcity://buildTypes":
 		return h.listBuildTypes(ctx)
-	case uri == "teamcity://builds":
+	case "teamcity://builds":
 		return h.listBuilds(ctx)
-	case uri == "teamcity://agents":
+	case "teamcity://agents":
 		return h.listAgents(ctx)
-	case uri == "teamcity://runtime":
+	case "teamcity://runtime":
 		return h.listRuntimeInfo(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported resource URI: %s", uri)

--- a/internal/teamcity/client.go
+++ b/internal/teamcity/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -782,10 +783,14 @@ func (c *Client) calculateDuration(startDate, endDate string) string {
 // FetchBuildLog fetches the build log for a specific build
 func (c *Client) FetchBuildLog(ctx context.Context, args json.RawMessage) (string, error) {
 	var req struct {
-		BuildID    string `json:"buildId"`
-		Plain      *bool  `json:"plain,omitempty"`
-		Archived   *bool  `json:"archived,omitempty"`
-		DateFormat string `json:"dateFormat,omitempty"`
+		BuildID       string `json:"buildId"`
+		Plain         *bool  `json:"plain,omitempty"`
+		Archived      *bool  `json:"archived,omitempty"`
+		DateFormat    string `json:"dateFormat,omitempty"`
+		MaxLines      *int   `json:"maxLines,omitempty"`
+		FilterPattern string `json:"filterPattern,omitempty"`
+		Severity      string `json:"severity,omitempty"`
+		TailLines     *int   `json:"tailLines,omitempty"`
 	}
 
 	if err := json.Unmarshal(args, &req); err != nil {
@@ -794,6 +799,18 @@ func (c *Client) FetchBuildLog(ctx context.Context, args json.RawMessage) (strin
 
 	if req.BuildID == "" {
 		return "", fmt.Errorf("buildId is required")
+	}
+
+	// Validate severity if provided
+	if req.Severity != "" {
+		validSeverities := map[string]bool{
+			"error":   true,
+			"warning": true,
+			"info":    true,
+		}
+		if !validSeverities[strings.ToLower(req.Severity)] {
+			return "", fmt.Errorf("invalid severity: must be 'error', 'warning', or 'info'")
+		}
 	}
 
 	start := time.Now()
@@ -866,16 +883,125 @@ func (c *Client) FetchBuildLog(ctx context.Context, args json.RawMessage) (strin
 			req.BuildID, len(respBody)), nil
 	}
 
-	// For plain text logs, return the content directly
+	// For plain text logs, apply filtering
 	logContent := string(respBody)
+	lines := strings.Split(logContent, "\n")
+	totalLines := len(lines)
 
-	// Add some metadata about the log
-	lineCount := len(strings.Split(logContent, "\n"))
+	// Apply filters
+	filteredLines := c.applyBuildLogFilters(lines, req.FilterPattern, req.Severity)
 
-	result := fmt.Sprintf("Build log for build %s (%d lines, %d bytes):\n\n%s",
-		req.BuildID, lineCount, len(respBody), logContent)
+	// Apply tail if requested
+	if req.TailLines != nil && *req.TailLines > 0 {
+		tailCount := *req.TailLines
+		if tailCount < len(filteredLines) {
+			filteredLines = filteredLines[len(filteredLines)-tailCount:]
+		}
+	}
+
+	// Apply max lines limit
+	if req.MaxLines != nil && *req.MaxLines > 0 {
+		maxLines := *req.MaxLines
+		if maxLines < len(filteredLines) {
+			filteredLines = filteredLines[:maxLines]
+		}
+	}
+
+	// Build result
+	result := fmt.Sprintf("Build log for build %s\n", req.BuildID)
+	result += fmt.Sprintf("Total lines: %d", totalLines)
+
+	if req.FilterPattern != "" || req.Severity != "" || req.TailLines != nil {
+		result += fmt.Sprintf(", Filtered lines: %d", len(filteredLines))
+	}
+
+	result += fmt.Sprintf(", Showing: %d lines\n\n", len(filteredLines))
+
+	if len(filteredLines) > 0 {
+		result += strings.Join(filteredLines, "\n")
+	} else {
+		result += "(No lines match the specified filters)"
+	}
 
 	return result, nil
+}
+
+// applyBuildLogFilters applies pattern and severity filters to log lines
+func (c *Client) applyBuildLogFilters(lines []string, pattern string, severity string) []string {
+	filtered := lines
+
+	// Apply pattern filter
+	if pattern != "" {
+		matched := make([]string, 0)
+		// Compile regex pattern
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			// If regex compilation fails, treat as literal string search
+			for _, line := range filtered {
+				if strings.Contains(line, pattern) {
+					matched = append(matched, line)
+				}
+			}
+		} else {
+			for _, line := range filtered {
+				if re.MatchString(line) {
+					matched = append(matched, line)
+				}
+			}
+		}
+		filtered = matched
+	}
+
+	// Apply severity filter
+	if severity != "" {
+		matched := make([]string, 0)
+		severityLower := strings.ToLower(severity)
+
+		// Common patterns for different severity levels
+		errorPatterns := []string{"error", "fail", "exception", "fatal", "[e]", "[error]"}
+		warningPatterns := []string{"warn", "warning", "[w]", "[warn]"}
+
+		var patterns []string
+		switch severityLower {
+		case "error":
+			patterns = errorPatterns
+		case "warning":
+			patterns = warningPatterns
+		case "info":
+			// For info, we exclude errors and warnings
+			for _, line := range filtered {
+				lineLower := strings.ToLower(line)
+				isErrorOrWarning := false
+
+				for _, p := range append(errorPatterns, warningPatterns...) {
+					if strings.Contains(lineLower, p) {
+						isErrorOrWarning = true
+						break
+					}
+				}
+
+				if !isErrorOrWarning && strings.TrimSpace(line) != "" {
+					matched = append(matched, line)
+				}
+			}
+			filtered = matched
+			return filtered
+		}
+
+		// For error and warning filters
+		for _, line := range filtered {
+			lineLower := strings.ToLower(line)
+			for _, p := range patterns {
+				if strings.Contains(lineLower, p) {
+					matched = append(matched, line)
+					break
+				}
+			}
+		}
+		filtered = matched
+	}
+
+	return filtered
 }
 
 // SearchBuildConfigurations searches for build configurations with comprehensive filters including parameters, steps, and VCS roots


### PR DESCRIPTION
Similar to @yigor, I had issues running the MCP tool `fetch_build_log` with an error similar to
```
   ⎿  Error: MCP tool "fetch_build_log" response (945195 tokens) exceeds maximum allowed tokens (25000). Please use pagination, filtering, or limit parameters to reduce the response size.
```

This PR adds the pagination and filtering as suggested by claude.

Note: this was mainly done with Claude. I'm not a Go developer, so while the code appears to work and looks fine to my eye, it's probably worth a close look.